### PR TITLE
Export edges as CSV

### DIFF
--- a/src/components/TimeSlicing.vue
+++ b/src/components/TimeSlicing.vue
@@ -127,7 +127,7 @@ export default defineComponent({
       slicedNetwork.forEach((slice) => {
         const timeObj = { slice: slice.slice, timeStart: slice.time[0], timeFinish: slice.time[1] };
         slice.network.edges.forEach((edge) => {
-          const rowObj = Object.assign(edge, timeObj);
+          const rowObj = { ...edge, ...timeObj };
           edges.push(rowObj);
         });
       });


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #9 

### Give a longer description of what this PR addresses and why it's needed
Talked to collaborator and they asked that the edge table be exported as a csv, rather than the previous json format. Since nodes are not affected by the time slicing, i chose to export only the edges.

### Provide pictures/videos of the behavior before and after these changes (optional)


### Are there any additional TODOs before this PR is ready to go?
